### PR TITLE
Update icons and links

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+### 0.0.11
+- Updated Maven link to redirect to maven central repository page
+- Updated Spring Boot link to redirect to spring landing page
+- Updated Cockroachdb icon from png to svg
+- Updated Graalvm icon order to be the second in backend list
+- Deleted Project Lombok from backend list
+- Deleted duplicated anchors tags
+
 ### 0.0.10
 - Reordered github stats
 

--- a/README.md
+++ b/README.md
@@ -62,99 +62,76 @@
     <a href="https://developer.mozilla.org/en-US/docs/Glossary/REST" target="_blank" rel="noreferrer">
         <img src="https://www.svgrepo.com/show/374044/rest.svg" alt="rest" width="40" height="40"/>
     </a>
-        <a href="https://graphql.org/" target="_blank" rel="noreferrer">
+    <a href="https://graphql.org/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/graphql/graphql-plain.svg" alt="graphql" width="40" height="40"/>
     </a>
-        <a href="https://grpc.io/" target="_blank" rel="noreferrer">
+    <a href="https://grpc.io/" target="_blank" rel="noreferrer">
         <img src="https://plugins.jetbrains.com/files/16889/400896/icon/pluginIcon.svg" alt="grpc" width="40" height="40"/>
     </a>
-        <a href="https://kafka.apache.org/" target="_blank" rel="noreferrer">
+    <a href="https://kafka.apache.org/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/apachekafka/apachekafka-original.svg" alt="kafka" width="40" height="40"/>
     </a>
-        <a href="https://socket.io/" target="_blank" rel="noreferrer">
+    <a href="https://socket.io/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/socketio/socketio-original.svg" alt="socketio" width="40" height="40"/>
     </a>
     <h3>Backend</h3>
-    </a>
-        <a href="https://www.java.com/" target="_blank" rel="noreferrer">
+    <a href="https://www.java.com/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/java/java-original.svg" alt="java" width="40" height="40"/>
-    </a>    
     </a>
-        <a href="https://projectlombok.org/" target="_blank" rel="noreferrer">
-        <img src="https://avatars.githubusercontent.com/u/45949248?s=200&v=4" alt="lombok" width="40" height="40"/>
+    <a href="https://www.graalvm.org/" target="_blank" rel="noreferrer">
+        <img src="https://www.graalvm.org/resources/img/home/graalvm_rabbit_icon.svg" alt="graalvm" width="40" height="40"/>
     </a>
+    <a href="https://central.sonatype.com/" target="_blank" rel="noreferrer">
+        <img src="https://cdn.icon-icons.com/icons2/2107/PNG/512/file_type_maven_icon_130397.png" alt="maven_central_repository" width="40" height="40"/>
     </a>
-        <a href="https://maven.apache.org/" target="_blank" rel="noreferrer">
-        <img src="https://cdn.icon-icons.com/icons2/2107/PNG/512/file_type_maven_icon_130397.png" alt="maven" width="40" height="40"/>
-    </a>
-    </a>
-        <a href="https://gradle.org/" target="_blank" rel="noreferrer">
+    <a href="https://gradle.org/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/gradle/gradle-plain.svg" alt="gradle" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://www.graalvm.org/" target="_blank" rel="noreferrer">
-        <img src="https://www.graalvm.org/resources/img/home/graalvm_rabbit_icon.svg" alt="graalvm" width="40" height="40"/>
-    </a>  
-    </a>
-        <a href="https://spring.io/projects/spring-boot" target="_blank" rel="noreferrer">
+    <a href="https://spring.io/" target="_blank" rel="noreferrer">
         <img src="https://spring.io/img/projects/spring-boot.svg" alt="spring-boot" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://quarkus.io/" target="_blank" rel="noreferrer">
+    <a href="https://quarkus.io/" target="_blank" rel="noreferrer">
         <img src="https://design.jboss.org/quarkus/logo/final/SVG/quarkus_icon_rgb_reverse.svg" alt="quarkus" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://junit.org/junit5/" target="_blank" rel="noreferrer">
+    <a href="https://junit.org/junit5/" target="_blank" rel="noreferrer">
         <img src="https://junit.org/junit5/assets/img/junit5-logo.png" alt="junit" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://site.mockito.org/" target="_blank" rel="noreferrer">
+    <a href="https://site.mockito.org/" target="_blank" rel="noreferrer">
         <img src="https://icons.veryicon.com/png/Food%20%26%20Drinks/Cocktails/Mojito.png" alt="mockito" width="40" height="40"/>
     </a>
     <h3>Database</h3>
-    </a>
-        <a href="https://www.prisma.io/" target="_blank" rel="noreferrer">
+    <a href="https://www.prisma.io/" target="_blank" rel="noreferrer">
         <img src="https://www.svgrepo.com/show/354210/prisma.svg" alt="prisma" width="40" height="40"/>
     </a>
+    <a href="https://www.cockroachlabs.com/" target="_blank" rel="noreferrer">
+        <img src="https://www.10xbanking.com/hubfs/CockroachLabs_Logo-Mark_Full-Color-Light-BG.svg" alt="cockroachdb" height="40"/>
     </a>
-        <a href="https://www.cockroachlabs.com/" target="_blank" rel="noreferrer">
-        <img src="https://ww2.freelogovectors.net/wp-content/uploads/2022/03/cockroachdb_logo_freelogovectors.net_.png?lossy=1&w=2560&ssl=1" alt="cockroachdb" width="40"/>
-    </a>
-    </a>
-        <a href="https://www.mongodb.com/" target="_blank" rel="noreferrer">
+    <a href="https://www.mongodb.com/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/mongodb/mongodb-original.svg" alt="mongodb" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://redis.io/" target="_blank" rel="noreferrer">
+    <a href="https://redis.io/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/redis/redis-original.svg" alt="redis" width="40" height="40"/>
     </a>
     <h3>DevOps</h3>
-    </a>
-        <a href="https://git-scm.com/" target="_blank" rel="noreferrer">
+    <a href="https://git-scm.com/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/git/git-original.svg" alt="git" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://www.docker.com/" target="_blank" rel="noreferrer">
+    <a href="https://www.docker.com/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/docker/docker-original.svg" alt="docker" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://kubernetes.io/" target="_blank" rel="noreferrer">
+    <a href="https://kubernetes.io/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/kubernetes/kubernetes-plain.svg" alt="kubernetes" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://circleci.com/" target="_blank" rel="noreferrer">
+    <a href="https://circleci.com/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/circleci/circleci-plain.svg" alt="circleci" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://www.elastic.co/elastic-stack" target="_blank" rel="noreferrer">
+    <a href="https://www.elastic.co/elastic-stack" target="_blank" rel="noreferrer">
         <img src="https://www.svgrepo.com/show/349350/elastic.svg" alt="elastic-stack" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://prometheus.io/" target="_blank" rel="noreferrer">
+    <a href="https://prometheus.io/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/prometheus/prometheus-original.svg" alt="prometheus" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://grafana.com/" target="_blank" rel="noreferrer">
+    <a href="https://grafana.com/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/grafana/grafana-original.svg" alt="graphana" width="40" height="40"/>
     </a>
 </p>
@@ -164,24 +141,19 @@
 <h2 align="left">🛠️ Tools</h2>
 <p align="left">
     <h3>Softwares</h3>
-    </a>
-        <a href="https://code.visualstudio.com/" target="_blank" rel="noreferrer">
+    <a href="https://code.visualstudio.com/" target="_blank" rel="noreferrer">
         <img src="https://cdn.jsdelivr.net/gh/devicons/devicon/icons/vscode/vscode-original.svg" alt="vscode" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://www.jetbrains.com/idea/" target="_blank" rel="noreferrer">
+    <a href="https://www.jetbrains.com/idea/" target="_blank" rel="noreferrer">
         <img src="https://upload.wikimedia.org/wikipedia/commons/9/9c/IntelliJ_IDEA_Icon.svg" alt="intellij-idea" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://www.google.com/chrome/" target="_blank" rel="noreferrer">
+    <a href="https://www.google.com/chrome/" target="_blank" rel="noreferrer">
         <img src="https://www.google.com/chrome/static/images/chrome-logo-m100.svg" alt="google-chrome" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://insomnia.rest/" target="_blank" rel="noreferrer">
+    <a href="https://insomnia.rest/" target="_blank" rel="noreferrer">
         <img src="https://www.svgrepo.com/show/353904/insomnia.svg" alt="insomnia" width="40" height="40"/>
     </a>
-    </a>
-        <a href="https://dbeaver.io/" target="_blank" rel="noreferrer">
+    <a href="https://dbeaver.io/" target="_blank" rel="noreferrer">
         <img src="https://raw.githubusercontent.com/wiki/dbeaver/dbeaver/images/dbeaver-head.png" alt="dbeaver" width="40" height="40"/>
     </a>
     <h3>Links</h3>


### PR DESCRIPTION
## Changes:
- Updated Maven link to redirect to maven central repository page
- Updated Spring Boot link to redirect to spring landing page
- Updated Cockroachdb icon from png to svg
- Updated Graalvm icon order to be the second in backend list
- Deleted Project Lombok from backend list
- Deleted duplicated anchors tags